### PR TITLE
Fix RFC name syntax checker

### DIFF
--- a/.tests/format-name
+++ b/.tests/format-name
@@ -13,8 +13,13 @@ match($0, /^[a-z-]+\/([0-9]{5})-[a-z0-9-]+\/README.md$/, grp) {
     next
 }
 
+# Allow some RFC-specific files
+/^[a-z-]+\/([0-9]{5})-[a-z0-9-]+\/[a-z0-9-]+.(png|svg)$/ {
+    next
+}
+
 {
-    printf "%s is formatted incorrectly!\n", $0
+    printf "%s is an unexpected filename!\n", $0
     status=1
 }
 

--- a/.tests/format-name
+++ b/.tests/format-name
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-ls */* | sort -g -k2 -t/ | gawk '
+find */ -type f | sort -g -k2 -t/ | gawk '
 BEGIN { seq=0; status=0 }
 
-match($0, /^[a-z-]+\/([0-9]{5})-[a-z0-9-]+.md$/, grp) {
+# Test the proper numbering of RFCs
+match($0, /^[a-z-]+\/([0-9]{5})-[a-z0-9-]+\/README.md$/, grp) {
     if (seq++ != grp[1] + 0) {
         printf "%s should have RFC #%05d!\n", $0, seq - 1
         status=1


### PR DESCRIPTION
Also, add the ability to have some RFC-associated files (such as images).