### PR TITLE
Accept .dot files in RFCs

### DIFF
--- a/.tests/format-name
+++ b/.tests/format-name
@@ -14,7 +14,7 @@ match($0, /^([0-9]{5})-[a-z0-9-]+\/README.md$/, grp) {
 }
 
 # Allow some RFC-specific files
-/^([0-9]{5})-[a-z0-9-]+\/[a-z0-9-]+.(png|svg)$/ {
+/^([0-9]{5})-[a-z0-9-]+\/[a-z0-9-]+.(png|svg|dot)$/ {
     next
 }
 


### PR DESCRIPTION
The sprints RFC (#27) includes Graphviz source, which cannot be included as one of the currently accepted file types of `.png` or `.svg`.

This PR allows `.dot` files as well.